### PR TITLE
Update manifest.json with missing 'version' to ensure compatibility with newer Home Assistants

### DIFF
--- a/custom_components/miio2/manifest.json
+++ b/custom_components/miio2/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "miio2",
   "name": "Xiaomi miio vacuum STYJ02YM",
+  "version": "0.109.0",
   "documentation": "https://github.com/KrzysztofHajdamowicz/home-assistant-vacuum-styj02ym",
   "requirements": [
     "construct==2.9.45",


### PR DESCRIPTION
https://github.com/KrzysztofHajdamowicz/home-assistant-vacuum-styj02ym/actions/runs/601197027
> [MANIFEST] No 'version' key in the manifest file. This will cause a future version of Home Assistant to block this integration.