### PR TITLE
Bump python-miio version to fix other xiaomi_miio integrations

### DIFF
--- a/custom_components/miio2/manifest.json
+++ b/custom_components/miio2/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/KrzysztofHajdamowicz/home-assistant-vacuum-styj02ym",
   "requirements": [
     "construct==2.9.45",
-    "python-miio==0.5.3"
+    "python-miio==0.5.5"
   ],
   "dependencies": [],
   "codeowners": ["@nqkdev", "@KrzysztofHajdamowicz"],


### PR DESCRIPTION
Fix for issue Breaks all xiaomi_miio integrations #37 . Tested and works well with HA 2021.4.6