### PR TITLE
Change the service API to match Xiaomi Miio and add segment cleaning

### DIFF
--- a/custom_components/miio2/services.yaml
+++ b/custom_components/miio2/services.yaml
@@ -1,333 +1,3 @@
-fan_set_buzzer_on:
-  description: Turn the buzzer on.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_buzzer_off:
-  description: Turn the buzzer off.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_led_on:
-  description: Turn the led on.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_led_off:
-  description: Turn the led off.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_child_lock_on:
-  description: Turn the child lock on.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_child_lock_off:
-  description: Turn the child lock off.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_favorite_level:
-  description: Set the favorite level.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-    level:
-      description: Level, between 0 and 16.
-      example: 1
-
-fan_set_fan_level:
-  description: Set the fan level.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-    level:
-      description: Level, between 1 and 3.
-      example: 1
-
-fan_set_led_brightness:
-  description: Set the led brightness.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-    brightness:
-      description: Brightness (0 = Bright, 1 = Dim, 2 = Off)
-      example: 1
-
-fan_set_auto_detect_on:
-  description: Turn the auto detect on.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_auto_detect_off:
-  description: Turn the auto detect off.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_learn_mode_on:
-  description: Turn the learn mode on.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_learn_mode_off:
-  description: Turn the learn mode off.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_volume:
-  description: Set the sound volume.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-    volume:
-      description: Volume, between 0 and 100.
-      example: 50
-
-fan_reset_filter:
-  description: Reset the filter lifetime and usage.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_extra_features:
-  description: Manipulates a storage register which advertises extra features. The Mi Home app evaluates the value. A feature called "turbo mode" is unlocked in the app on value 1.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-    features:
-      description: Integer, known values are 0 (default) and 1 (turbo mode).
-      example: 1
-
-fan_set_target_humidity:
-  description: Set the target humidity.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-    humidity:
-      description: Target humidity. Allowed values are 30, 40, 50, 60, 70 and 80.
-      example: 50
-
-fan_set_dry_on:
-  description: Turn the dry mode on.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_dry_off:
-  description: Turn the dry mode off.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "fan.xiaomi_miio_device"
-
-fan_set_motor_speed:
-  description: Set the target motor speed.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: 'fan.xiaomi_miio_device'
-    motor_speed:
-      description: Set RPM of motor speed, between 200 and 2000.
-      example: 1100
-
-light_set_scene:
-  description: Set a fixed scene.
-  fields:
-    entity_id:
-      description: Name of the light entity.
-      example: "light.xiaomi_miio"
-    scene:
-      description: Number of the fixed scene, between 1 and 4.
-      example: 1
-
-light_set_delayed_turn_off:
-  description: Delayed turn off.
-  fields:
-    entity_id:
-      description: Name of the light entity.
-      example: "light.xiaomi_miio"
-    time_period:
-      description: Time period for the delayed turn off.
-      example: "5, '0:05', {'minutes': 5}"
-
-light_reminder_on:
-  description: Enable the eye fatigue reminder/notification (EYECARE SMART LAMP 2 ONLY).
-  fields:
-    entity_id:
-      description: "Name of the entity to act on."
-      example: "light.xiaomi_miio"
-
-light_reminder_off:
-  description: Disable the eye fatigue reminder/notification (EYECARE SMART LAMP 2 ONLY).
-  fields:
-    entity_id:
-      description: "Name of the entity to act on."
-      example: "light.xiaomi_miio"
-
-light_night_light_mode_on:
-  description: Turn the eyecare mode on (EYECARE SMART LAMP 2 ONLY).
-  fields:
-    entity_id:
-      description: "Name of the entity to act on."
-      example: "light.xiaomi_miio"
-
-light_night_light_mode_off:
-  description: Turn the eyecare mode fan_set_dry_off (EYECARE SMART LAMP 2 ONLY).
-  fields:
-    entity_id:
-      description: "Name of the entity to act on."
-      example: "light.xiaomi_miio"
-
-light_eyecare_mode_on:
-  description: Enable the eye fatigue reminder/notification (EYECARE SMART LAMP 2 ONLY).
-  fields:
-    entity_id:
-      description: "Name of the entity to act on."
-      example: "light.xiaomi_miio"
-
-light_eyecare_mode_off:
-  description: Disable the eye fatigue reminder/notification (EYECARE SMART LAMP 2 ONLY).
-  fields:
-    entity_id:
-      description: "Name of the entity to act on."
-      example: "light.xiaomi_miio"
-
-remote_learn_command:
-  description: 'Learn an IR command, press "Call Service", point the remote at the IR device, and the learned command will be shown as a notification in Overview.'
-  fields:
-    entity_id:
-      description: "Name of the entity to learn command from."
-      example: "remote.xiaomi_miio"
-    slot:
-      description: "Define the slot used to save the IR command (Value from 1 to 1000000)"
-      example: "1"
-    timeout:
-      description: "Define the timeout in seconds, before which the command must be learned."
-      example: "30"
-
-remote_set_led_on:
-  description: 'Turn on blue LED.'
-  fields:
-    entity_id:
-      description: "Name of the entity to turn LED on."
-      example: "remote.xiaomi_miio"
-
-remote_set_led_off:
-  description: 'Turn off blue LED.'
-  fields:
-    entity_id:
-      description: "Name of the entity to turn LED off."
-      example: "remote.xiaomi_miio"
-
-switch_set_wifi_led_on:
-  description: Turn the wifi led on.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "switch.xiaomi_miio_device"
-
-switch_set_wifi_led_off:
-  description: Turn the wifi led off.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "switch.xiaomi_miio_device"
-
-switch_set_power_price:
-  description: Set the power price.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "switch.xiaomi_miio_device"
-    mode:
-      description: Power price, between 0 and 999.
-      example: 31
-
-switch_set_power_mode:
-  description: Set the power mode.
-  fields:
-    entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "switch.xiaomi_miio_device"
-    mode:
-      description: Power mode, valid values are 'normal' and 'green'.
-      example: "green"
-
-vacuum_remote_control_start:
-  description: Start remote control of the vacuum cleaner. You can then move it with `remote_control_move`, when done call `remote_control_stop`.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
-
-vacuum_remote_control_stop:
-  description: Stop remote control mode of the vacuum cleaner.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
-
-vacuum_remote_control_move:
-  description: Remote control the vacuum cleaner, make sure you first set it in remote control mode with `remote_control_start`.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
-    velocity:
-      description: Speed, between -0.29 and 0.29.
-      example: "0.2"
-    rotation:
-      description: Rotation, between -179 degrees and 179 degrees.
-      example: "90"
-    duration:
-      description: Duration of the movement.
-      example: "1500"
-
-vacuum_remote_control_move_step:
-  description: Remote control the vacuum cleaner, only makes one move and then stops.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
-    velocity:
-      description: Speed, between -0.29 and 0.29.
-      example: "0.2"
-    rotation:
-      description: Rotation, between -179 degrees and 179 degrees.
-      example: "90"
-    duration:
-      description: Duration of the movement.
-      example: "1500"
-
 vacuum_clean_zone:
   description: Start the cleaning operation in the selected areas for the number of repeats indicated.
   fields:
@@ -335,24 +5,24 @@ vacuum_clean_zone:
       description: Name of the vacuum entity.
       example: "vacuum.xiaomi_vacuum_cleaner"
     zone:
-      description: Array of zones. Each zone is an array of 4 integer values.
-      example: "[[23510,25311,25110,26362]]"
+      description: Array of zones. Each zone is an array of 4 float values. The values are in meters, where (0, 0) is the robot attached to the docking station.
+      example: "[[-1,-1,2,2]]"
     repeats:
       description: Number of cleaning repeats for each zone between 1 and 3.
       example: "1"
 
 vacuum_goto:
-  description: Go to the specified coordinates.
+  description: Start cleaning around the specified coordinate (spot cleaning).
   fields:
     entity_id:
       description: Name of the vacuum entity.
       example: "vacuum.xiaomi_vacuum_cleaner"
     x_coord:
       description: x-coordinate.
-      example: 27500
+      example: "-1"
     y_coord:
       description: y-coordinate.
-      example: 32000
+      example: 2
 
 vacuum_clean_segment:
   description: Start cleaning of the specified segment(s).
@@ -362,4 +32,27 @@ vacuum_clean_segment:
       example: "vacuum.xiaomi_vacuum_cleaner"
     segments:
       description: Segments.
-      example: "[1,2]"
+      example: "[10,11]"
+
+xiaomi_clean_zone:
+  description: Obsoleted, see vacuum_clean_zone.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: "vacuum.xiaomi_vacuum_cleaner"
+    zone:
+      description: Array of zones. Each zone is an array of 4 float values. The values are in meters, where (0, 0) is the robot attached to the docking station.
+      example: "[[-1,-1,2,2]]"
+    repeats:
+      description: Number of cleaning repeats for each zone between 1 and 3.
+      example: "1"
+
+xiaomi_clean_point:
+  description: Obsoleted, see vacuum_goto.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: "vacuum.xiaomi_vacuum_cleaner"
+    point:
+      description: An array specifying a coordinate pair.
+      example: "[-1,2]"

--- a/custom_components/miio2/vacuum.py
+++ b/custom_components/miio2/vacuum.py
@@ -53,10 +53,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 VACUUM_SERVICE_SCHEMA = vol.Schema(
     {vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids})
-SERVICE_CLEAN_ZONE = "xiaomi_clean_zone"
+SERVICE_CLEAN_ZONE = "vacuum_clean_zone"
+SERVICE_GOTO = "vacuum_goto"
+SERVICE_CLEAN_SEGMENT = "vacuum_clean_segment"
+SERVICE_OBS_CLEAN_ZONE = "xiaomi_clean_zone"
 SERVICE_CLEAN_POINT = "xiaomi_clean_point"
 ATTR_ZONE_ARRAY = "zone"
 ATTR_ZONE_REPEATER = "repeats"
+ATTR_X_COORD = "x_coord"
+ATTR_Y_COORD = "y_coord"
+ATTR_SEGMENTS = "segments"
 ATTR_POINT = "point"
 SERVICE_SCHEMA_CLEAN_ZONE = VACUUM_SERVICE_SCHEMA.extend(
     {
@@ -73,6 +79,20 @@ SERVICE_SCHEMA_CLEAN_ZONE = VACUUM_SERVICE_SCHEMA.extend(
         ),
     }
 )
+SERVICE_SCHEMA_GOTO = VACUUM_SERVICE_SCHEMA.extend(
+    {
+        vol.Required(ATTR_X_COORD): vol.Coerce(float),
+        vol.Required(ATTR_Y_COORD): vol.Coerce(float),
+    }
+)
+SERVICE_SCHEMA_CLEAN_SEGMENT = VACUUM_SERVICE_SCHEMA.extend(
+    {
+        vol.Required(ATTR_SEGMENTS): vol.Any(
+            vol.Coerce(int),
+            [vol.Coerce(int)]
+        ),
+    }
+)
 SERVICE_SCHEMA_CLEAN_POINT = VACUUM_SERVICE_SCHEMA.extend(
     {
         vol.Required(ATTR_POINT): vol.All(
@@ -84,6 +104,18 @@ SERVICE_SCHEMA_CLEAN_POINT = VACUUM_SERVICE_SCHEMA.extend(
 )
 SERVICE_TO_METHOD = {
     SERVICE_CLEAN_ZONE: {
+        "method": "async_clean_zone",
+        "schema": SERVICE_SCHEMA_CLEAN_ZONE,
+    },
+    SERVICE_GOTO: {
+        "method": "async_goto",
+        "schema": SERVICE_SCHEMA_GOTO,
+    },
+    SERVICE_CLEAN_SEGMENT: {
+        "method": "async_clean_segment",
+        "schema": SERVICE_SCHEMA_CLEAN_SEGMENT,
+    },
+    SERVICE_OBS_CLEAN_ZONE: {
         "method": "async_clean_zone",
         "schema": SERVICE_SCHEMA_CLEAN_ZONE,
     },
@@ -466,6 +498,20 @@ class MiroboVacuum2(StateVacuumEntity):
         await self._try_command("Unable to clean zone: %s", self._vacuum.raw_command, 'set_uploadmap', [1]) \
             and await self._try_command("Unable to clean zone: %s", self._vacuum.raw_command, 'set_zone', result) \
             and await self._try_command("Unable to clean zone: %s", self._vacuum.raw_command, 'set_mode', [3, 1])
+
+    async def async_goto(self, x_coord, y_coord):
+        """Clean area around the specified coordinates"""
+        self._last_clean_point = [x_coord, y_coord]
+        await self._try_command("Unable to goto: %s", self._vacuum.raw_command, 'set_uploadmap', [0]) \
+            and await self._try_command("Unable to goto: %s", self._vacuum.raw_command, 'set_pointclean', [1, x_coord, y_coord])
+
+    async def async_clean_segment(self, segments):
+        """Clean selected segment(s) (rooms)"""
+        if isinstance(segments, int):
+            segments = [segments]
+
+        await self._try_command("Unable to clean segments: %s", self._vacuum.raw_command, 'set_uploadmap', [1]) \
+            and await self._try_command("Unable to clean segments: %s", self._vacuum.raw_command, 'set_mode_withroom', [0, 1, len(segments)] + segments)
 
     async def async_clean_point(self, point):
         """Clean selected area"""


### PR DESCRIPTION
This PR improves the following areas:

- the Xiaomi Miio integration changed the service calls xiaomi_clean_zone to vacuum_clean_zone and xiaomi_clean_point to vacuum_goto a year ago. Introducing the new calls, but keeping the old ones for compatibility (can be removed later)
- adding a services.yaml describing the supported service calls
- adding a new call vacuum_clean_segment for segment (room) cleaning

All of them are tested with my Viomi V2 Pro.

This PR is a reformatted version which I had sent upstream (but hasn't been accepted yet).